### PR TITLE
Implement Dockerfile and CI/CD to DockerHub

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,36 @@
+name: ci-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/clairvoyance:latest
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,14 +1,15 @@
 name: ci-to-dockerhub
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Tests"]
+    branches: [main]
+    types: [completed]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE files
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Image: python:3.9.6-slim-buster
+FROM python@sha256:ab2e6f2a33c44bd0cda2138a8308ca45145edd21ba80a125c9df57c46a255839 as build
+
+RUN apt update \
+    && apt upgrade -y \
+    && apt install -y python3-dev build-essential
+
+ENV VIRTUAL_ENV=/tmp/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY requirements.txt /tmp/
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+
+
+# Image: python:3.9.6-alpine3.14
+FROM python@sha256:3e7e8a57a959c393797f0c90fa7b0fdbf7a40c4a274028e3f28a4f33d4783866
+
+WORKDIR /home/clairvoyance
+
+RUN adduser \
+    --home "$(pwd)" \
+    --gecos "" \
+    --disabled-password \
+    clairvoyance
+
+COPY --from=build /tmp/venv .venv/
+COPY clairvoyance clairvoyance/
+
+USER clairvoyance
+ENV PYTHONPATH=/home/clairvoyance
+ENTRYPOINT [".venv/bin/python3", "clairvoyance/__main__.py"]


### PR DESCRIPTION
This PR adds a Dockerfile to clairvoyance with the following considerations:

- Adds deterministic base images for reproducible builds.
- Adds a multi-stage build that keeps the image size at about 60MB in size.
- Adds a least-privileged user in compliance with Docker security best practices.

We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub.

This is a nice tool but I needed to run it from a Docker container, so here is my contribution. If you merge I'll go ahead later and add a few installation instructions for Docker to the README.md file.