### PR TITLE
add: add proxies option to pass traffic through burp suite

### DIFF
--- a/clairvoyance/__main__.py
+++ b/clairvoyance/__main__.py
@@ -59,7 +59,7 @@ def parse_args():
         "-p",
         "--proxy",
         dest="proxies",
-        default=False,
+        default=None,
         required=False,
         help="Use the specified HTTP proxy (e.g. BurpSuite to debug requests). Proxy can also be defined by standard environment variables 'http_proxy', 'https_proxy', 'no_proxy', and 'all_proxy'. Uppercase variants of these variables are also supported. This argument is passed directly to the https://requests.readthedocs.io/en/latest/user/advanced/#proxies parameter.",
     )

--- a/clairvoyance/__main__.py
+++ b/clairvoyance/__main__.py
@@ -61,7 +61,7 @@ def parse_args():
         dest="proxies",
         default=False,
         required=False,
-        help="Use a proxy such as BurpSuite to debug requests.",
+        help="Use the specified HTTP proxy (e.g. BurpSuite to debug requests). Proxy can also be defined by standard environment variables 'http_proxy', 'https_proxy', 'no_proxy', and 'all_proxy'. Uppercase variants of these variables are also supported. This argument is passed directly to the https://requests.readthedocs.io/en/latest/user/advanced/#proxies parameter.",
     )
     parser.add_argument("url")
 

--- a/clairvoyance/__main__.py
+++ b/clairvoyance/__main__.py
@@ -55,6 +55,14 @@ def parse_args():
         type=argparse.FileType("r"),
         help="This wordlist will be used for all brute force effots (fields, arguments and so on)",
     )
+    parser.add_argument(
+        "-p",
+        "--proxy",
+        dest="proxies",
+        default=False,
+        required=False,
+        help="Use a proxy such as BurpSuite to debug requests.",
+    )
     parser.add_argument("url")
 
     return parser.parse_args()
@@ -77,6 +85,10 @@ if __name__ == "__main__":
     config = graphql.Config()
     config.url = args.url
     config.verify = not args.insecure
+    
+    if args.proxies != False:
+        config.proxies = args.proxies
+        
     for h in args.headers:
         key, value = h.split(": ", 1)
         config.headers[key] = value

--- a/clairvoyance/__main__.py
+++ b/clairvoyance/__main__.py
@@ -60,7 +60,7 @@ def parse_args():
         "--proxy",
         dest="proxies",
         default=None,
-        required=False,
+        metavar="[protocol://]host[:port]",
         help="Use the specified HTTP proxy (e.g. BurpSuite to debug requests). Proxy can also be defined by standard environment variables 'http_proxy', 'https_proxy', 'no_proxy', and 'all_proxy'. Uppercase variants of these variables are also supported. This argument is passed directly to the https://requests.readthedocs.io/en/latest/user/advanced/#proxies parameter.",
     )
     parser.add_argument("url")

--- a/clairvoyance/__main__.py
+++ b/clairvoyance/__main__.py
@@ -88,6 +88,8 @@ if __name__ == "__main__":
     
     if args.proxies != False:
         config.proxies = args.proxies
+    else:
+        config.proxies = False
         
     for h in args.headers:
         key, value = h.split(": ", 1)

--- a/clairvoyance/graphql.py
+++ b/clairvoyance/graphql.py
@@ -1,3 +1,4 @@
+import re
 import urllib3
 import requests
 from urllib3.exceptions import InsecureRequestWarning
@@ -12,7 +13,8 @@ from typing import Any
 from typing import Set
 
 
-def post(url, data=None, json=None, **kwargs):
+def post(url, data=None, json=None, proxies=None, **kwargs):
+    
     session = requests.Session()
 
     retries = urllib3.util.Retry(
@@ -34,7 +36,10 @@ def post(url, data=None, json=None, **kwargs):
 
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-
+    
+    if proxies != None:
+        session.proxies = {"http": proxies, "https": proxies}
+            
     response = session.post(url, data=data, json=json, **kwargs)
 
     return response

--- a/clairvoyance/oracle.py
+++ b/clairvoyance/oracle.py
@@ -70,13 +70,26 @@ def probe_valid_fields(
         bucket = wordlist[i : i + config.bucket_size]
 
         document = input_document.replace("FUZZ", " ".join(bucket))
-
-        response = graphql.post(
-            config.url,
-            headers=config.headers,
-            json={"query": document},
-            verify=config.verify,
-        )
+        
+        if config.proxies != False:
+            
+            response = graphql.post(
+                config.url,
+                headers=config.headers,
+                proxies=config.proxies,
+                json={"query": document},
+                verify=config.verify,
+            )
+            
+        else:
+            
+            response = graphql.post(
+                config.url,
+                headers=config.headers,
+                json={"query": document},
+                verify=config.verify,
+            )
+            
         errors = response.json()["errors"]
         logging.debug(
             f"Sent {len(bucket)} fields, recieved {len(errors)} errors in {response.elapsed.total_seconds()} seconds"


### PR DESCRIPTION
Hi, hope you are well :)

Thanks a lot for the tool, it contributes a modification to watch traffic using BurpSuite.

The example command is as follows:

```
python3 -m clairvoyance -vv -o output -w google-10000-english.txt -p http://127.0.0.1:8080 -k https://site/graphql
```