### PR TITLE
feat(docker): multi platform build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/clairvoyance:latest
+          platform: linux/amd64, linux/arm64
           
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Closes #45.

We internally use that `platforms` pattern to build our services for Mac M1 and linux.
You may want to add several platforms (but I am not able to test others): https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-set-the-target-platforms-for-the-build---platform