### PR TITLE
remove duplicate license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ packages = [
     { include = "clairvoyance" }
 ]
 include = [
-    "LICENSE",
     "clairvoyance/wordlist.txt"
 ]
 readme = "README.md"


### PR DESCRIPTION
The license file is included two times and one is at the wrong place.

If we take a look at the wheel dist, we can see there is `LICENSE` at the root and also `clairvoyance-2.0.1.dist-info/LICENSE`:

```
➜ 7z l dist/clairvoyance-2.0.1-py3-none-any.whl 
...
   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
1980-01-01 00:00:00 .....        11357         3948  LICENSE
1980-01-01 00:00:00 .....           41           40  clairvoyance/__init__.py
1980-01-01 00:00:00 .....           71           69  clairvoyance/__main__.py
1980-01-01 00:00:00 .....         3300         1073  clairvoyance/cli.py
1980-01-01 00:00:00 .....         1998          692  clairvoyance/client.py
1980-01-01 00:00:00 .....          271          175  clairvoyance/config.py
1980-01-01 00:00:00 .....           55           55  clairvoyance/entities/__init__.py
1980-01-01 00:00:00 .....          659          263  clairvoyance/entities/context.py
1980-01-01 00:00:00 .....          647          314  clairvoyance/entities/interfaces.py
1980-01-01 00:00:00 .....          420          245  clairvoyance/entities/meta.py
1980-01-01 00:00:00 .....          761          360  clairvoyance/entities/primitives.py
1980-01-01 00:00:00 .....        11696         2556  clairvoyance/graphql.py
1980-01-01 00:00:00 .....        18550         3795  clairvoyance/oracle.py
1980-01-01 00:00:00 .....         2072          770  clairvoyance/utils.py
1980-01-01 00:00:00 .....        75153        34959  clairvoyance/wordlist.txt
1980-01-01 00:00:00 .....        11357         3948  clairvoyance-2.0.1.dist-info/LICENSE
1980-01-01 00:00:00 .....         3815         1657  clairvoyance-2.0.1.dist-info/METADATA
1980-01-01 00:00:00 .....           88           84  clairvoyance-2.0.1.dist-info/WHEEL
1980-01-01 00:00:00 .....           49           41  clairvoyance-2.0.1.dist-info/entry_points.txt
2016-01-01 00:00:00 .....         1636          897  clairvoyance-2.0.1.dist-info/RECORD
------------------- ----- ------------ ------------  ------------------------
2016-01-01 00:00:00             143996        55941  20 files
```

But this is an issue, because when you install it on your system, it deploys one of the license file on the root path of the python site package directory:

```
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/bin/
-rwxr-xr-x root/root       208 2022-11-23 14:44 usr/bin/clairvoyance
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/python3.10/
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/python3.10/site-packages/
-rw-r--r-- root/root     11357 2022-11-23 14:44 usr/lib/python3.10/site-packages/LICENSE
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/
-rw-r--r-- root/root         4 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/INSTALLER
-rw-r--r-- root/root     11357 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/LICENSE
-rw-r--r-- root/root      3815 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/METADATA
-rw-r--r-- root/root      1924 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/RECORD
-rw-r--r-- root/root         0 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/REQUESTED
-rw-r--r-- root/root        88 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/WHEEL
-rw-r--r-- root/root        49 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/entry_points.txt
-rw-r--r-- root/root        41 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/__init__.py
-rw-r--r-- root/root        71 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/__main__.py
-rw-r--r-- root/root      3300 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/cli.py
-rw-r--r-- root/root      1998 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/client.py
-rw-r--r-- root/root       271 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/config.py
drwxr-xr-x root/root         0 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/
-rw-r--r-- root/root        55 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/__init__.py
-rw-r--r-- root/root       659 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/context.py
-rw-r--r-- root/root       647 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/interfaces.py
-rw-r--r-- root/root       420 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/meta.py
-rw-r--r-- root/root       761 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/entities/primitives.py
-rw-r--r-- root/root     11696 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/graphql.py
-rw-r--r-- root/root     18550 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/oracle.py
-rw-r--r-- root/root      2072 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/utils.py
-rw-r--r-- root/root     75153 2022-11-23 14:44 usr/lib/python3.10/site-packages/clairvoyance/wordlist.txt
```

So by removing the LICENSE from include it will remove `usr/lib/python3.10/site-packages/LICENSE` but keep `usr/lib/python3.10/site-packages/clairvoyance-2.0.1.dist-info/LICENSE`.

Other packages like https://github.com/Porchetta-Industries/CrackMapExec/pull/689 have the same issue which conflicts and prevent installing new tools with the same issue.

```
error: failed to commit transaction (conflicting files)
clairvoyance: /usr/lib/python3.10/site-packages/LICENSE exists in filesystem (owned by crackmapexec)
```