### PR TITLE
Disable SSL Verification to resolve certificate verification error

### DIFF
--- a/clairvoyance/client.py
+++ b/clairvoyance/client.py
@@ -55,6 +55,7 @@ class Client(IClient):
                     self._url,
                     json=gql_document,
                     proxy=self.proxy,
+                    verify_ssl=False
                 )
 
                 if response.status >= 500:


### PR DESCRIPTION
This pull request addresses the certificate verification error that is occurring when attempting to post to `https://XXX.XXX.XXX.XXX/graphql`. The error message is as follows:

```
WARNING | Error posting to https://xxx.xxx.xxx.xxx/graphql: Cannot connect to host xxx.xxx.xxx.xxx:443 ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:992)')]
```
### Changes Made

To resolve this issue, I have temporarily disabled SSL verification. While this is not a permanent solution, it will allow the connection to be established without the certificate verification error. Please note that this is a temporary measure, and a more robust solution for handling SSL certificates should be implemented in the future.

### Testing

I have tested the changes in this pull request, and I can confirm that the error no longer occurs, and the connection to `https://XXX.XXX.XXX.XXX/graphql` is successful.

### Review

I kindly request a review of this pull request to ensure that it correctly addresses the certificate verification error. Additionally, I welcome any suggestions for a more permanent solution to handle SSL certificates in a secure manner.

Thank you for your attention to this matter.