### PR TITLE
GH-43: Add version tag on Docker Hub release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,12 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Set up Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/clairvoyance
       
       - name: Build and push
         id: docker_build
@@ -68,7 +74,8 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/clairvoyance:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           
       - name: Image digest


### PR DESCRIPTION
Fixes #43

[Basic](https://github.com/docker/metadata-action?tab=readme-ov-file#basic) example was used, nothing fancy. Later the versioning might be adjusted.