### PR TITLE
Update deprecated aiohttp TCPConnector SSL setting

### DIFF
--- a/clairvoyance/client.py
+++ b/clairvoyance/client.py
@@ -44,9 +44,7 @@ class Client(IClient):  # pylint: disable=too-many-instance-attributes
 
         async with self._semaphore:
             if not self._session:
-                connector = aiohttp.TCPConnector(
-                    verify_ssl=(not self.disable_ssl_verify)
-                )
+                connector = aiohttp.TCPConnector(ssl=not self.disable_ssl_verify)
                 self._session = aiohttp.ClientSession(
                     headers=self._headers, connector=connector
                 )


### PR DESCRIPTION
Instead of `verify_ssl`, `ssl_context` and `fingerprint`, `ssl` is used now. https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.TCPConnector