### PR TITLE
Fix multisuggestion regexes + input Object suffix assertion

### DIFF
--- a/clairvoyance/oracle.py
+++ b/clairvoyance/oracle.py
@@ -384,7 +384,7 @@ def get_typeref(
         elif context == FuzzingContext.ARGUMENT:
             kind = "INPUT_OBJECT"
             name = (
-                name.rstrip("Input") + "Input"
+                name.removesuffix("Input") + "Input"
             )  # Make sure `Input` is always once at the end
         else:
             log().debug(f"Unknown kind for `typeref`: '{error_message}'")

--- a/clairvoyance/oracle.py
+++ b/clairvoyance/oracle.py
@@ -25,7 +25,7 @@ _FIELD_REGEXES = {
         r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"]""" + MAIN_REGEX + r"""['"]\.""",
         r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"](""" + MAIN_REGEX + r""")['"]\. Did you mean to use an inline fragment on ['"]""" + MAIN_REGEX + r"""['"]\?""",
         r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"](""" + MAIN_REGEX + r""")['"]\. Did you mean to use an inline fragment on ['"]""" + MAIN_REGEX + r"""['"] or ['"]""" + MAIN_REGEX + r"""['"]\?""",
-        r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"](""" + MAIN_REGEX + r""")['"]\. Did you mean to use an inline fragment on (['"]""" + MAIN_REGEX + r"""['"], )+(or ['"]""" + MAIN_REGEX + r"""['"])?\?"""
+        r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"](""" + MAIN_REGEX + r""")['"]\. Did you mean to use an inline fragment on (['"]""" + MAIN_REGEX + r"""['"],? )+(or ['"]""" + MAIN_REGEX + r"""['"])?\?"""
     ],
     'VALID_FIELD': [
         r"""Field ['"](?P<field>""" + MAIN_REGEX + r""")['"] of type ['"](?P<typeref>""" + MAIN_REGEX + r""")['"] must have a selection of subfields\. Did you mean ['"]""" + MAIN_REGEX + r"""( \{ \.\.\. \})?['"]\?""",
@@ -38,7 +38,7 @@ _FIELD_REGEXES = {
         r"""Cannot query field ['"]""" + MAIN_REGEX + r"""['"] on type ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean ['"](?P<one>""" + MAIN_REGEX + r""")['"] or ['"](?P<two>""" + MAIN_REGEX + r""")['"]\?"""
     ],
     'MULTI_SUGGESTION': [
-        r"""Cannot query field ['"](""" + MAIN_REGEX + r""")['"] on type ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean (?P<multi>(['"]""" + MAIN_REGEX + r"""['"], )+)(or ['"](?P<last>""" + MAIN_REGEX + r""")['"])?\?"""
+        r"""Cannot query field ['"](""" + MAIN_REGEX + r""")['"] on type ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean (?P<multi>(['"]""" + MAIN_REGEX + r"""['"],? )+)(or ['"](?P<last>""" + MAIN_REGEX + r""")['"])?\?"""
     ],
 }
 
@@ -57,7 +57,8 @@ _ARG_REGEXES = {
         r"""Unknown argument ['"]""" + MAIN_REGEX + r"""['"] on field ['"]""" + MAIN_REGEX + r"""['"]( of type ['"]""" + MAIN_REGEX + r"""['"])?\. Did you mean ['"](?P<first>""" + MAIN_REGEX + r""")['"] or ['"](?P<second>""" + MAIN_REGEX + r""")['"]\?"""
     ],
     'MULTI_SUGGESTION': [
-        r"""Unknown argument ['"]""" + MAIN_REGEX + r"""['"] on field ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean (?P<multi>(['"]""" + MAIN_REGEX + r"""['"], )+)(or ['"](?P<last>""" + MAIN_REGEX + r""")['"])?\?"""
+        r"""Unknown argument ['"]""" + MAIN_REGEX + r"""['"] on field ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean (?P<multi>(['"]""" + MAIN_REGEX + r"""['"],? )+)(or ['"](?P<last>""" + MAIN_REGEX + r""")['"])?\?""",
+        r"""Unknown argument ['"]""" + MAIN_REGEX + r"""['"] on field ['"]""" + MAIN_REGEX + r"""['"] of type ['"]""" + MAIN_REGEX + r"""['"]\. Did you mean (?P<multi>(['"]""" + MAIN_REGEX + r"""['"],? )+)(or ['"](?P<last>""" + MAIN_REGEX + r""")['"])?\?"""
     ],
 }
 
@@ -139,7 +140,7 @@ def get_valid_fields(error_message: str) -> Set[str]:
 
             for m in match.group("multi").split(", "):
                 if m:
-                    valid_fields.add(m.strip('"').strip("'"))
+                    valid_fields.add(m.strip("'\" "))
             if match.group("last"):
                 valid_fields.add(match.group("last"))
 
@@ -319,7 +320,7 @@ def get_valid_args(error_message: str) -> Set[str]:
             if match:
                 for m in match.group("multi").split(", "):
                     if m:
-                        valid_args.add(m.strip('"').strip("'"))
+                        valid_args.add(m.strip("'\" "))
 
                 if match.group("last"):
                     valid_args.add(match.group("last"))

--- a/tests/oracle_test.py
+++ b/tests/oracle_test.py
@@ -33,6 +33,12 @@ class TestGetValidFields(unittest.TestCase):
         )
         self.assertEqual(got_2, want_2)
 
+        want_3 = {"pastes", "users", "audits"}
+        got_3 = oracle.get_valid_fields(
+            'Cannot query field "assets" on type "Query". Did you mean "pastes", "users" or "audits"?'
+        )
+        self.assertEqual(got_3, want_3)
+
     def test_single_suggestion(self) -> None:
         want = {"homes"}
         got = oracle.get_valid_fields(
@@ -76,6 +82,12 @@ class TestGetValidArgs(unittest.TestCase):
             'Unknown argument "fares" on field "Organization.vulnerabilities". Did you mean "after", "first", or "types"?'
         )
         self.assertEqual(got_3, want_3)
+
+        want = {"port", "host", "path"}
+        got = oracle.get_valid_args(
+            'Unknown argument "pot" on field "importPaste" of type "Mutations". Did you mean "port", "host" or "path"?'
+        )
+        self.assertEqual(got, want)
 
 
 class TestGetTypeRef(unittest.TestCase):

--- a/tests/oracle_test.py
+++ b/tests/oracle_test.py
@@ -105,6 +105,20 @@ class TestGetTypeRef(unittest.TestCase):
         )
         self.assertEqual(got, want)
 
+    def test_input_suffix(self) -> None:
+        want = graphql.TypeRef(
+            name="OrganizationInput",
+            kind="INPUT_OBJECT",
+            is_list=False,
+            non_null_item=False,
+            non_null=True,
+        )
+        got = oracle.get_typeref(
+            'Field "Organization" argument "input" of type "OrganizationInput!" is required, but it was not provided.',
+            FuzzingContext.ARGUMENT,
+        )
+        self.assertEqual(got, want)
+
     def test_inputfield_object_non_nullable(self) -> None:
         want = graphql.TypeRef(
             name="SetArmedStateForHomeInput",


### PR DESCRIPTION
The regexes for multiple suggestions assume a comma is present before the final "or" of the error message :

- matched : `Did you mean "pastes", "users", or "audits"?`
- didn't match : `Did you mean "pastes", "users" or "audits"?`

This PR makes the comma optional, as it doesn't appear in error messages produced by DVGA. I suppose this might happen to other apps as well.

This PR also fixes an issue with the "Input" suffix of input objects.
The operation `name.rstrip("Input")`  would in some cases produce incorrect results: `OrganizationInput` => `Organizatio`

Unit tests have been added to cover those changes.